### PR TITLE
add support for relative imports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes
 1.3.1 (unreleased)
 ------------------
 
-- No changes yet.
+- Added support for relative imports.
 
 
 1.3.0 (2013-04-10)

--- a/tests/doctests.txt
+++ b/tests/doctests.txt
@@ -19,9 +19,9 @@ Imports in doctest sections inside docstrings are also handled
 
     >>> for imp in find_imports('marmalade.py'):
     ...     print imp
-    ImportInfo('doctest', 'marmalade.py', 2)
-    ImportInfo('sys', 'marmalade.py', 5)
-    ImportInfo('gc', 'marmalade.py', 9)
+    ImportInfo('doctest', 'marmalade.py', 2, None)
+    ImportInfo('sys', 'marmalade.py', 5, None)
+    ImportInfo('gc', 'marmalade.py', 9, None)
 
 Note that we carefully adjust line numbers to make sure they match reality.
 
@@ -40,7 +40,7 @@ no line number.  We don't crash:
 
     >>> for imp in find_imports('jam.py'):
     ...     print imp
-    ImportInfo('sys', 'jam.py', 3)
+    ImportInfo('sys', 'jam.py', 3, None)
 
 
 Doctest errors
@@ -84,8 +84,8 @@ is
     >>> for imp in find_imports('jelly.py'):
     ...     print imp
     jelly.py:2: syntax error in doctest
-    ImportInfo('sys', 'jelly.py', 5)
-    ImportInfo('os', 'jelly.py', 9)
+    ImportInfo('sys', 'jelly.py', 5, None)
+    ImportInfo('os', 'jelly.py', 9, None)
 
 
 Nested docstrings
@@ -102,5 +102,5 @@ This is probably overkill, but we handle them recursively:
     ... ''')
     >>> for imp in find_imports('sandwitch.py'):
     ...     print imp
-    ImportInfo('sys', 'sandwitch.py', 5)
+    ImportInfo('sys', 'sandwitch.py', 5, None)
 

--- a/tests/imports.txt
+++ b/tests/imports.txt
@@ -9,6 +9,7 @@ All kinds of import statements are handled
     ... import sys
     ... import os.path
     ... import email.Message as EM
+    ... from . import foobar
     ... from cStringIO import StringIO
     ... from cPickle import dumps as D
     ... from sys import (argv,
@@ -20,16 +21,17 @@ All kinds of import statements are handled
 
     >>> for imp in find_imports('marmalade.py'):
     ...     print imp
-    ImportInfo('sys', 'marmalade.py', 2)
-    ImportInfo('os.path', 'marmalade.py', 3)
-    ImportInfo('email.Message', 'marmalade.py', 4)
-    ImportInfo('cStringIO.StringIO', 'marmalade.py', 5)
-    ImportInfo('cPickle.dumps', 'marmalade.py', 6)
-    ImportInfo('sys.argv', 'marmalade.py', 7)
-    ImportInfo('sys.exc_info', 'marmalade.py', 8)
-    ImportInfo('sys.exit', 'marmalade.py', 9)
-    ImportInfo('email.*', 'marmalade.py', 10)
-    ImportInfo('imaginary.package', 'marmalade.py', 11)
+    ImportInfo('sys', 'marmalade.py', 2, None)
+    ImportInfo('os.path', 'marmalade.py', 3, None)
+    ImportInfo('email.Message', 'marmalade.py', 4, None)
+    ImportInfo('foobar', 'marmalade.py', 5, 1)
+    ImportInfo('cStringIO.StringIO', 'marmalade.py', 6, 0)
+    ImportInfo('cPickle.dumps', 'marmalade.py', 7, 0)
+    ImportInfo('sys.argv', 'marmalade.py', 8, 0)
+    ImportInfo('sys.exc_info', 'marmalade.py', 9, 0)
+    ImportInfo('sys.exit', 'marmalade.py', 10, 0)
+    ImportInfo('email.*', 'marmalade.py', 11, 0)
+    ImportInfo('imaginary.package', 'marmalade.py', 12, None)
 
 Note how we carefully try to make sure the line numbers are correct (e.g.
 'exit' is shown as imported on line 9, even though the AST node says the
@@ -44,5 +46,6 @@ We print warnings when we cannot find a module/package
     >>> from findimports import ModuleGraph
     >>> graph = ModuleGraph()
     >>> graph.parseFile('marmalade.py')
+    marmalade.py: could not find foobar
     marmalade.py: could not find imaginary.package
 

--- a/tests/name-tracking.txt
+++ b/tests/name-tracking.txt
@@ -8,16 +8,19 @@ expressions
 
     >>> open('marmalade.py', 'w').write('''
     ... import sys, os
+    ... from .. import foobar
     ... my_name_is = sys.argv[0]
     ... ''')
 
     >>> imports, unused_names = find_imports_and_track_names('marmalade.py')
     >>> for imp in imports:
     ...     print imp
-    ImportInfo('sys', 'marmalade.py', 2)
-    ImportInfo('os', 'marmalade.py', 2)
+    ImportInfo('sys', 'marmalade.py', 2, None)
+    ImportInfo('os', 'marmalade.py', 2, None)
+    ImportInfo('foobar', 'marmalade.py', 3, 2)
 
     >>> for name in unused_names:
     ...     print name
-    ImportInfo('os', 'marmalade.py', 2)
+    ImportInfo('os', 'marmalade.py', 2, None)
+    ImportInfo('foobar', 'marmalade.py', 3, 2)
 

--- a/tests/scopes.txt
+++ b/tests/scopes.txt
@@ -19,15 +19,15 @@ expressions
     >>> imports, unused_names = find_imports_and_track_names('marmalade.py')
     >>> for imp in imports:
     ...     print imp
-    ImportInfo('os', 'marmalade.py', 2)
-    ImportInfo('shutil', 'marmalade.py', 2)
-    ImportInfo('sys', 'marmalade.py', 4)
-    ImportInfo('gc', 'marmalade.py', 4)
-    ImportInfo('sys', 'marmalade.py', 7)
+    ImportInfo('os', 'marmalade.py', 2, None)
+    ImportInfo('shutil', 'marmalade.py', 2, None)
+    ImportInfo('sys', 'marmalade.py', 4, None)
+    ImportInfo('gc', 'marmalade.py', 4, None)
+    ImportInfo('sys', 'marmalade.py', 7, None)
 
     >>> for name in unused_names:
     ...     print name
-    ImportInfo('shutil', 'marmalade.py', 2)
-    ImportInfo('gc', 'marmalade.py', 4)
-    ImportInfo('sys', 'marmalade.py', 7)
+    ImportInfo('shutil', 'marmalade.py', 2, None)
+    ImportInfo('gc', 'marmalade.py', 4, None)
+    ImportInfo('sys', 'marmalade.py', 7, None)
 

--- a/tests/zipfiles.txt
+++ b/tests/zipfiles.txt
@@ -5,11 +5,11 @@ Modules can be placed in zip files
 
     >>> from findimports import ModuleGraph
     >>> graph = ModuleGraph()
-    >>> graph.findModuleOfName('zippedsample', '<stdin>')
+    >>> graph.findModuleOfName('zippedsample', None, '<stdin>')
     'zippedsample'
 
 If a module cannot be located, we get an extra warning
 
-    >>> graph.findModuleOfName('imaginarysample', '<stdin>')
+    >>> graph.findModuleOfName('imaginarysample', None, '<stdin>')
     <stdin>: could not find imaginarysample
     'imaginarysample'


### PR DESCRIPTION
per [pep 328](http://www.python.org/dev/peps/pep-0328/), relative imports add the ability to alter an import based on a "level" counter, which syntactically is a number of dots.   With these changes I've managed to produce successful graphs for parts of SQLAlchemy (which uses all relative imports) without any errors.  I've updated the tests though there should probably be some tests that test specifically the path resolution against the "sample-tree" package.
