### PR TITLE
Fix GitHub Actions badge link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Licence: GPL v2 or later (https://www.gnu.org/copyleft/gpl.html)
 |buildstatus|_ |appveyor|_ |coverage|_
 
 .. |buildstatus| image:: https://github.com/mgedmin/findimports/workflows/build/badge.svg?branch=master
-.. _buildstatus: https://github.com/mgedmin/findimports/actions?query=workflow%3Atests
+.. _buildstatus: https://github.com/mgedmin/findimports/actions
 
 .. |appveyor| image:: https://ci.appveyor.com/api/projects/status/github/mgedmin/findimports?branch=master&svg=true
 .. _appveyor: https://ci.appveyor.com/project/mgedmin/findimports


### PR DESCRIPTION
I've renamed the workflow, so it should be ?query=workflow:build, but
actually there's only one workflow so no need to filter.