### PR TITLE
Rewrite to use ArgumentParser and make actions explicit

### DIFF
--- a/tests/cmdline.txt
+++ b/tests/cmdline.txt
@@ -5,9 +5,8 @@ An invalid argument causes a short error message
 
     >>> from findimports import main
     >>> exitcode = main(['findimports', '--nosuchargument'])
-    Usage: findimports [options] [filename|dirname ...]
-    <BLANKLINE>
-    findimports: error: no such option: --nosuchargument
+    usage: findimports [action] [options] [filename|dirname ...]
+    findimports: error: unrecognized arguments: --nosuchargument
 
     >>> exitcode
     2
@@ -15,7 +14,7 @@ An invalid argument causes a short error message
 You can ask for a help message
 
     >>> exitcode = main(['findimports', '--help'])  # doctest: +ELLIPSIS
-    Usage: findimports [options] [filename|dirname ...]
+    usage: findimports [action] [options] [filename|dirname ...]
     <BLANKLINE>
     FindImports is a script that processes Python module dependencies...
     ...


### PR DESCRIPTION
I found it quite confusing that actions and other options are not distinguished. It's not clear which parameters one can use simultaneously and what effect that has.

<s>I'd be even better define that on the parser level and error out, but that likely implies a change to the CLI API (not sure if that'd be ok). So as a quick-fix, let's at least document the current behavior.</s>

Edit: This PR switches to `ArgumentParser` which allows for reasonable automatic checking that only one action is given on the command line. It also makes the *actions* more obvious in the `--help` message.

Also partly adresses #6.